### PR TITLE
Unset cameraMode if no photo is taken

### DIFF
--- a/app/(tabs)/camera.tsx
+++ b/app/(tabs)/camera.tsx
@@ -1,5 +1,6 @@
 import { useIsFocused } from "@react-navigation/native";
-import { useRouter } from "expo-router";
+import { useFocusEffect, useRouter } from "expo-router";
+import { useCallback, useRef } from "react";
 
 import { CameraUI } from "../../components/CameraUI";
 import { CameraMode, useCamera } from "../../context/CameraContext";
@@ -9,14 +10,30 @@ const DEFAULT_MODE = CameraMode.Placement; // Camera-first marker placement is t
 export default function CameraScreen() {
   const router = useRouter();
   const isFocused = useIsFocused();
-  const { captureMode, setCaptureMode, setCapturedImage } = useCamera();
+  const { captureMode, setCapturedImage } = useCamera();
+
+  const pictureTaken = useRef(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      // useCallback prevents effect from triggering on re-renders e.g. state updates
+      pictureTaken.current = false;
+      return () => {
+        // Unset mode if no picture was taken and user leaves the tab
+        if (!pictureTaken) {
+          captureMode.current = CameraMode.None;
+        }
+      };
+    }, [])
+  );
 
   const onPictureTaken = (uri: string) => {
     // Adjust the mode, set the URI, and jump to the default tab, which is index.tsx
-    switch (captureMode) {
+    pictureTaken.current = true;
+    switch (captureMode.current) {
       //STUB: Add more cases as needed.
-      case CameraMode.None: // With mode specified we use the default
-        setCaptureMode(DEFAULT_MODE);
+      case CameraMode.None: // With no mode specified we use the default
+        captureMode.current = DEFAULT_MODE;
         break;
     }
     setCapturedImage(uri);

--- a/app/(tabs)/camera.tsx
+++ b/app/(tabs)/camera.tsx
@@ -18,9 +18,15 @@ export default function CameraScreen() {
     useCallback(() => {
       // useCallback prevents effect from triggering on re-renders e.g. state updates
       pictureTaken.current = false;
+      switch (captureMode.current) {
+        //STUB: Add more cases as needed.
+        case CameraMode.None: // With no mode specified we use the default
+          captureMode.current = DEFAULT_MODE;
+          break;
+      }
       return () => {
         // Unset mode if no picture was taken and user leaves the tab
-        if (!pictureTaken) {
+        if (pictureTaken.current === false) {
           captureMode.current = CameraMode.None;
         }
       };
@@ -30,12 +36,6 @@ export default function CameraScreen() {
   const onPictureTaken = (uri: string) => {
     // Adjust the mode, set the URI, and jump to the default tab, which is index.tsx
     pictureTaken.current = true;
-    switch (captureMode.current) {
-      //STUB: Add more cases as needed.
-      case CameraMode.None: // With no mode specified we use the default
-        captureMode.current = DEFAULT_MODE;
-        break;
-    }
     setCapturedImage(uri);
     router.navigate("/");
   };

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -4,7 +4,11 @@ import { StatusBar } from "expo-status-bar";
 import { useEffect, useRef, useState } from "react";
 import { Alert, Image, Text, TouchableOpacity, View } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { ResumableZoom, ResumableZoomRefType } from "react-native-zoom-toolkit";
+import {
+  CommonZoomState,
+  ResumableZoom,
+  ResumableZoomRefType,
+} from "react-native-zoom-toolkit";
 
 import LoadingOverlay from "../../components/LoadingOverlay";
 import MyFloorPlans from "../../components/floorplans";
@@ -289,6 +293,14 @@ export default function HomeScreen() {
       }
     );
 
+  const onResumablePlacementUpdate = (state: CommonZoomState<number>) => {
+    "worklet";
+    onResumableUpdate(state);
+    const { x, y, width, height } = getVisibleRectFromState(state);
+    previewMarker.x.value = x + width / 2;
+    previewMarker.y.value = y + height / 2;
+  };
+
   // Runs whenever capturedImage updates e.g. when a new photo is taken using camera.tsx
   useEffect(() => {
     if (!capturedImage) return;
@@ -417,17 +429,11 @@ export default function HomeScreen() {
           ref={resumableRef}
           extendGestures // This should be used with extendBorders or it might act weird.
           extendBorders // extendBorders is our own addition. Don't forget to apply the patch!
-          onUpdate={(state) => {
-            "worklet";
-            if (captureMode.current === CameraMode.Placement) {
-              onResumableUpdate(state);
-              const { x, y, width, height } = getVisibleRectFromState(state);
-              previewMarker.x.value = x + width / 2;
-              previewMarker.y.value = y + height / 2;
-            } else {
-              onResumableUpdate(state);
-            }
-          }}
+          onUpdate={
+            captureMode.current === CameraMode.Placement
+              ? onResumablePlacementUpdate
+              : onResumableUpdate
+          }
           onLongPress={(event) => {
             if (captureMode.current === CameraMode.Placement) {
               // Confirm the image placement if one is ongoing

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -55,7 +55,7 @@ export default function HomeScreen() {
     withMarkerAt,
   } = useFloorplan();
 
-  const { capturedImage, captureMode, setCaptureMode } = useCamera();
+  const { capturedImage, captureMode } = useCamera();
 
   const { error, log } = useLogger();
   const { showToast } = useToast();
@@ -193,7 +193,7 @@ export default function HomeScreen() {
     setShowNewMarkerOptions(false);
     setShowTempMarker(false);
     router.navigate("/camera");
-    setCaptureMode(CameraMode.Addition);
+    captureMode.current = CameraMode.Addition;
   };
 
   const handleAddFromCameraRollToMarker = async () => {
@@ -234,7 +234,7 @@ export default function HomeScreen() {
     if (!selectedMarkerId) return;
     setShowNewMarkerOptions(false);
     router.navigate("/camera");
-    setCaptureMode(CameraMode.Addition);
+    captureMode.current = CameraMode.Addition;
   };
 
   const handleDeletePhoto = (photo: PhotoData) => {
@@ -292,7 +292,7 @@ export default function HomeScreen() {
   // Runs whenever capturedImage updates e.g. when a new photo is taken using camera.tsx
   useEffect(() => {
     if (!capturedImage) return;
-    if (captureMode === CameraMode.Placement && resumableRef.current) {
+    if (captureMode.current === CameraMode.Placement && resumableRef.current) {
       // Image should be added to a user-selected marker or used to create a new marker at a user-defined position
       const { x, y, width, height } = resumableRef.current.getVisibleRect();
       // Change the preview marker coordinates to the center of the (element in) ResumableZoom
@@ -300,7 +300,7 @@ export default function HomeScreen() {
       previewMarker.x.value = x + width / 2;
       previewMarker.y.value = y + height / 2;
       findImagePlacementTarget(previewMarker.x.value, previewMarker.y.value);
-    } else if (captureMode === CameraMode.Addition) {
+    } else if (captureMode.current === CameraMode.Addition) {
       // Image should be added to the currently selected marker or used to create a new marker at the preview
       const imageDate = new Date().toISOString().split("T")[0];
       withLoadingOverlay("Running blur detection...", async () => {
@@ -328,7 +328,7 @@ export default function HomeScreen() {
           throw caughtError;
         });
       // Addition complete. Unset the mode but keep the URI
-      setCaptureMode(CameraMode.None);
+      captureMode.current = CameraMode.None;
     }
   }, [capturedImage]);
 
@@ -419,7 +419,7 @@ export default function HomeScreen() {
           extendBorders // extendBorders is our own addition. Don't forget to apply the patch!
           onUpdate={(state) => {
             "worklet";
-            if (captureMode === CameraMode.Placement) {
+            if (captureMode.current === CameraMode.Placement) {
               onResumableUpdate(state);
               const { x, y, width, height } = getVisibleRectFromState(state);
               previewMarker.x.value = x + width / 2;
@@ -429,12 +429,12 @@ export default function HomeScreen() {
             }
           }}
           onLongPress={(event) => {
-            if (captureMode === CameraMode.Placement) {
+            if (captureMode.current === CameraMode.Placement) {
               // Confirm the image placement if one is ongoing
               console.info(`Confirming image placement via long press..`);
               const imageDate = new Date().toISOString().split("T")[0];
               setPendingPhotos([{ uri: capturedImage, date: imageDate }]);
-              setCaptureMode(CameraMode.None);
+              captureMode.current = CameraMode.None;
             }
           }}
           onTap={(event) => {
@@ -457,7 +457,7 @@ export default function HomeScreen() {
                 // Abort if the tap was outside the child element
                 return;
               }
-              if (captureMode === CameraMode.Placement) {
+              if (captureMode.current === CameraMode.Placement) {
                 // Move to the position of the tap for quick navigation
                 resumableRef.current.zoom(scale, { x: event.x, y: event.y });
                 // Check if a marker was hit and select it
@@ -469,7 +469,7 @@ export default function HomeScreen() {
             }
           }}
           onGestureEnd={() => {
-            if (captureMode === CameraMode.Placement) {
+            if (captureMode.current === CameraMode.Placement) {
               findImagePlacementTarget(
                 previewMarker.x.value,
                 previewMarker.y.value
@@ -495,7 +495,7 @@ export default function HomeScreen() {
             ))}
 
             {/* Preview of marker to camera-first create */}
-            {captureMode === CameraMode.Placement || showTempMarker ? (
+            {captureMode.current === CameraMode.Placement || showTempMarker ? (
               <MarkerElement
                 x={previewMarker.x}
                 y={previewMarker.y}
@@ -562,7 +562,7 @@ export default function HomeScreen() {
         </View>
 
         <Text style={styles.instructions}>
-          {`${captureMode === CameraMode.Placement ? `Tap and hold to ${selectedMarkerId ? "add the image" : "create marker"}` : "Tap on the floor plan to place a marker"}`}
+          {`${captureMode.current === CameraMode.Placement ? `Tap and hold to ${selectedMarkerId ? "add the image" : "create marker"}` : "Tap on the floor plan to place a marker"}`}
         </Text>
         {(loadingText || isSavingMarkers) && (
           <LoadingOverlay text={loadingText ?? "Saving marker..."} />

--- a/context/CameraContext.tsx
+++ b/context/CameraContext.tsx
@@ -1,8 +1,10 @@
 import React, {
   createContext,
   Dispatch,
+  RefObject,
   SetStateAction,
   useContext,
+  useRef,
   useState,
 } from "react";
 
@@ -13,16 +15,13 @@ export enum CameraMode {
   Addition = "Addition", // Marker associated with image. Don't use placement system.
 }
 
-const CameraContext = createContext<
-  | {
-      // Returned types go here:
-      capturedImage: string; // URI of the most recent image captured
-      setCapturedImage: Dispatch<SetStateAction<string>>;
-      captureMode: CameraMode; // What to do with the capturedImage
-      setCaptureMode: Dispatch<SetStateAction<CameraMode>>;
-    }
-  | undefined
->(undefined);
+interface CameraContextReturn {
+  capturedImage: string; // URI of the most recent image captured
+  setCapturedImage: Dispatch<SetStateAction<string>>;
+  captureMode: RefObject<CameraMode>; // What to do with the capturedImage
+}
+
+const CameraContext = createContext<CameraContextReturn | undefined>(undefined);
 
 export const CameraContextProvider = ({
   children,
@@ -30,11 +29,11 @@ export const CameraContextProvider = ({
   children: React.ReactNode;
 }) => {
   const [capturedImage, setCapturedImage] = useState("");
-  const [captureMode, setCaptureMode] = useState(CameraMode.None);
+  const captureMode = useRef(CameraMode.None);
 
   return (
     <CameraContext.Provider
-      value={{ capturedImage, setCapturedImage, captureMode, setCaptureMode }}
+      value={{ capturedImage, setCapturedImage, captureMode }}
     >
       {children}
     </CameraContext.Provider>


### PR DESCRIPTION
camera.tsx now maintains a reference to track if a photo was taken since the tab was focused. captureMode is set to None if this is false and the tab gets unfocused. Also, captureMode is a reference to guarantee that changes apply before navigation routing.