### PR TITLE
Bandaid fix to stop java.lang.illegalStateException

### DIFF
--- a/context/Overlays.tsx
+++ b/context/Overlays.tsx
@@ -8,12 +8,7 @@ import React, {
   useState,
 } from "react";
 import { StyleProp, StyleSheet, View, ViewStyle } from "react-native";
-import Animated, {
-  FadeIn,
-  FadeOut,
-  SlideInDown,
-  SlideOutDown,
-} from "react-native-reanimated";
+import Animated from "react-native-reanimated";
 
 import { Toast } from "../components/Toast";
 

--- a/context/Overlays.tsx
+++ b/context/Overlays.tsx
@@ -113,6 +113,8 @@ type OverlayProps = React.PropsWithChildren<{
 }>;
 
 const getAnimationSet = (animationType: OverlayAnimationType) => {
+  return { entering: undefined, exiting: undefined };
+  /*
   switch (animationType) {
     case "none":
       return { entering: undefined, exiting: undefined };
@@ -121,6 +123,7 @@ const getAnimationSet = (animationType: OverlayAnimationType) => {
     case "fade":
       return { entering: FadeIn, exiting: FadeOut };
   }
+  */
 };
 
 // Wraps a ReactNode and moves it to the overlay modal on mount.


### PR DESCRIPTION
Per https://github.com/software-mansion/react-native-reanimated/issues/7493, it appears that the problem is caused by layout animations, which we use for overlays. They have been "disabled" for now.